### PR TITLE
Fixes for NuGet Packager

### DIFF
--- a/Solutions/Main/Framework/NuGet/Packager.cs
+++ b/Solutions/Main/Framework/NuGet/Packager.cs
@@ -123,6 +123,8 @@ namespace MSBuild.ExtensionPack.NuGet
 
         /// <summary>
         /// Gets or sets the Release Notes of the NuGet package.
+        /// This field only shows up when the package is an update to a previously installed package. 
+        /// It is displayed where the Description would normally be displayed.
         /// </summary>
         public string ReleaseNotes { get; set; }
 
@@ -137,16 +139,28 @@ namespace MSBuild.ExtensionPack.NuGet
         public string Tags { get; set; }
 
         /// <summary>
-        /// Gets or sets the NuGet Output file
+        /// Gets or sets the summary, a short description of the package.
+        /// If specified, this shows up in the middle pane of the Add Package Dialog. 
+        /// If not specified, a truncated version of the description is used instead.
         /// </summary>
-        [Required]
-        public string OutputFile { get; set; }
+        public string Summary { get; set; }
+
+        /// <summary>
+        /// Gets or sets the locale ID for the package, such as en-us.
+        /// </summary>
+        public string Language { get; set; }
 
         /// <summary>
         /// Gets or sets the directory containing the command line tool, NuGet.exe.
         /// If none is specified, will default to Resources directory of the currently executing assembly.
         /// </summary>
         public string NuGetExeDir { get; set; }
+
+        /// <summary>
+        /// Gets or sets the NuGet Output file
+        /// </summary>
+        [Required]
+        public string OutputFile { get; set; }
 
         /// <summary>
         /// Gets or sets the Dependencies of the NuGet package. 
@@ -382,6 +396,7 @@ namespace MSBuild.ExtensionPack.NuGet
             string executionDirectory = Path.GetDirectoryName(nugetSpecificationFile);
 
             // Default to Resources directory so behavior is consistent with previous versions (when NuGetExeDir is not specified).
+            
             NuGetExeDir = NuGetExeDir ?? Path.Combine(Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location), @"Resources\");
             string nugetFilePath = Path.Combine(NuGetExeDir, "NuGet.exe");
 
@@ -433,11 +448,15 @@ namespace MSBuild.ExtensionPack.NuGet
                     new XElement(defaultNamespace + "title", this.Title),
                     new XElement(defaultNamespace + "authors", this.Authors),
                     new XElement(defaultNamespace + "owners", this.Owners),
+                    new XElement(defaultNamespace + "description", this.Description),
+                    new XElement(defaultNamespace + "releaseNotes", this.ReleaseNotes),
+                    new XElement(defaultNamespace + "summary", this.Summary),
+                    new XElement(defaultNamespace + "language", this.Language),
+                    new XElement(defaultNamespace + "projectUrl", this.ProjectUrl),
                     new XElement(defaultNamespace + "iconUrl", this.IconUrl),
                     new XElement(defaultNamespace + "licenseUrl", this.LicenseUrl),
-                    new XElement(defaultNamespace + "projectUrl", this.ProjectUrl),
+                    new XElement(defaultNamespace + "copyright", this.CopyrightText),
                     new XElement(defaultNamespace + "requireLicenseAcceptance", this.RequiresExplicitLicensing.ToString().ToLower(CultureInfo.CurrentCulture)),
-                    new XElement(defaultNamespace + "description", this.Description),
                     new XElement(defaultNamespace + "tags", this.Tags)));
 
             if (this.Dependencies != null)


### PR DESCRIPTION
Added some new metadata properties and fixed some which were not being written to the generated package. Available properties should now match the Nuspec Reference.

Also added an optional property to allow custom specification of NuGet.exe command line tool location since the project was making an assumption about its location.
