### PR TITLE
Add support for VS2015's TF.exe location

### DIFF
--- a/Solutions/Main/Framework/VisualStudio/TFSSource.cs
+++ b/Solutions/Main/Framework/VisualStudio/TFSSource.cs
@@ -668,6 +668,9 @@ namespace MSBuild.ExtensionPack.VisualStudio
             string vstools = string.Empty;
             switch (this.Version)
             {
+                case "2015":
+                    vstools = Environment.GetEnvironmentVariable("VS140COMNTOOLS");
+                    break;
                 case "2013":
                     vstools = Environment.GetEnvironmentVariable("VS120COMNTOOLS");
                     break;

--- a/Solutions/Main/Framework/VisualStudio/TFSSourceAdmin.cs
+++ b/Solutions/Main/Framework/VisualStudio/TFSSourceAdmin.cs
@@ -159,6 +159,9 @@ namespace MSBuild.ExtensionPack.VisualStudio
             string vstools = string.Empty;
             switch (this.Version)
             {
+                case "2015":
+                    vstools = Environment.GetEnvironmentVariable("VS140COMNTOOLS");
+                    break;
                 case "2013":
                     vstools = Environment.GetEnvironmentVariable("VS120COMNTOOLS");
                     break;


### PR DESCRIPTION
Add a new case statement for VS 2015 with it's tools environment variable.