### PR TITLE
Avoid CDATA in CDATA

### DIFF
--- a/Solutions/Main/Loggers/Framework/XmlFileLogger.cs
+++ b/Solutions/Main/Loggers/Framework/XmlFileLogger.cs
@@ -309,6 +309,10 @@ namespace MSBuild.ExtensionPack.Loggers
                 return;
             }
 
+			// Avoid CDATA in CDATA
+			message = message.Replace("<![CDATA[", "");
+			message = message.Replace("]]>", "");
+			
             message = message.Replace("&", "&amp;");
             if (escape)
             {


### PR DESCRIPTION
If something writes out CDATA into the log, this logger crashes with the following error message:

> MSBUILD : error MSB4017: The build stopped unexpectedly because of an unexpected logger failure.
> Microsoft.Build.Exceptions.InternalLoggerException: The build stopped unexpectedly because of an unexpected logger failure. ---> Microsoft.Build.Exceptions.InternalLoggerException: The build stopped u
> nexpectedly because of an unexpected logger failure. ---> System.ArgumentException: Cannot have ']]>' inside an XML CDATA block.
> at System.Xml.XmlTextWriter.WriteCData(String text)
> at MSBuild.ExtensionPack.Loggers.XmlFileLogger.WriteMessage(String message, Boolean escape)

To avoid this I have simply removed CDATA boundaries from the message.

You can test it by using this MSBuild task: 

`<Message Text="&lt;![CDATA[ something]]>" />`