### PR TITLE
Added user parameter in MSBuild.ExtensionPack.VisualStudio.TfsSource TaskAction="GetPendingChanges"

### DIFF
--- a/Solutions/Main/Framework/Security/Certificate.cs
+++ b/Solutions/Main/Framework/Security/Certificate.cs
@@ -3,6 +3,9 @@
 //-----------------------------------------------------------------------
 namespace MSBuild.ExtensionPack.Security
 {
+    using Microsoft.Build.Framework;
+    using Microsoft.Build.Utilities;
+    using MSBuild.ExtensionPack.Security.Extended;
     using System;
     using System.Globalization;
     using System.IO;
@@ -12,9 +15,6 @@ namespace MSBuild.ExtensionPack.Security
     using System.Security.Cryptography;
     using System.Security.Cryptography.X509Certificates;
     using System.Security.Principal;
-    using Microsoft.Build.Framework;
-    using Microsoft.Build.Utilities;
-    using MSBuild.ExtensionPack.Security.Extended;
 
     internal enum CryptGetProvParamType
     {
@@ -517,14 +517,14 @@ namespace MSBuild.ExtensionPack.Security
                 this.CertInfo.SetMetadata("SubjectNameOidValue", cert.SubjectName.Oid.Value ?? string.Empty);
                 this.CertInfo.SetMetadata("SerialNumber", cert.SerialNumber ?? string.Empty);
                 this.CertInfo.SetMetadata("Archived", cert.Archived.ToString());
-                this.CertInfo.SetMetadata("NotBefore", cert.NotBefore.ToString());
+                this.CertInfo.SetMetadata("NotBefore", cert.NotBefore.ToString(CultureInfo.CurrentCulture));
                 this.CertInfo.SetMetadata("FriendlyName", cert.FriendlyName);
                 this.CertInfo.SetMetadata("HasPrivateKey", cert.HasPrivateKey.ToString());
                 this.CertInfo.SetMetadata("Thumbprint", cert.Thumbprint ?? string.Empty);
                 this.CertInfo.SetMetadata("Version", cert.Version.ToString());
                 this.CertInfo.SetMetadata("SignatureAlgorithm", cert.SignatureAlgorithm.FriendlyName);
                 this.CertInfo.SetMetadata("IssuerName", cert.IssuerName.Name);
-                this.CertInfo.SetMetadata("NotAfter", cert.NotAfter.ToString());
+                this.CertInfo.SetMetadata("NotAfter", cert.NotAfter.ToString(CultureInfo.CurrentCulture));
 
                 var privateKeyFileName = GetKeyFileName(cert);
                 if (!string.IsNullOrEmpty(privateKeyFileName))

--- a/Solutions/Main/Framework/VisualStudio/TFSSource.cs
+++ b/Solutions/Main/Framework/VisualStudio/TFSSource.cs
@@ -59,7 +59,7 @@ namespace MSBuild.ExtensionPack.VisualStudio
     /// <para><i>GetWorkingChangeset</i> (<b>Required: </b>ItemPath <b>Optional: </b>Login, Server, WorkingDirectory, Recursive <b>Output:</b> ExitCode, Changeset)</para>
     /// <para><i>Merge</i> (<b>Required: </b>ItemPath, Destination <b>Optional: </b>Login, Server, Recursive, VersionSpec, Version, Baseless, Force <b>Output:</b> ExitCode)</para>
     /// <para><i>Resolve</i> (<b>Required: </b>ItemPath or ItemCol <b>Optional: </b>Login, Server, Recursive, Version, Auto, NewName)</para>
-    /// <para><i>GetPendingChanges</i> (<b>Required: </b>ItemPath <b>Optional: </b>Login, Server, Recursive, Version <b>Output: </b>PendingChanges, PendingChangesExist <b>Output:</b> ExitCode, PendingChangesExistItem)</para>
+    /// <para><i>GetPendingChanges</i> (<b>Required: </b>ItemPath <b>Optional: </b>Login, Server, Recursive, Version, User <b>Output: </b>PendingChanges, PendingChangesExist <b>Output:</b> ExitCode, PendingChangesExistItem)</para>
     /// <para><i>UndoCheckout</i> (<b>Required: </b>ItemPath or ItemCol <b>Optional: </b>Login, Server, Version, WorkingDirectory, Recursive <b>Output:</b> ExitCode)</para>
     /// <para><i>Undelete</i> (<b>Required: </b>ItemPath or ItemCol <b>Optional: </b>Login, Server, Version, WorkingDirectory, Recursive <b>Output:</b> ExitCode)</para>
     /// <para><b>Remote Execution Support:</b> NA</para>

--- a/Solutions/Main/Framework/VisualStudio/TFSSource.cs
+++ b/Solutions/Main/Framework/VisualStudio/TFSSource.cs
@@ -3,12 +3,12 @@
 //-----------------------------------------------------------------------
 namespace MSBuild.ExtensionPack.VisualStudio
 {
+    using Microsoft.Build.Framework;
+    using Microsoft.Build.Utilities;
     using System;
     using System.Globalization;
     using System.IO;
     using System.Text;
-    using Microsoft.Build.Framework;
-    using Microsoft.Build.Utilities;
 
     /// <summary>
     /// AutoArg enumeration
@@ -19,27 +19,27 @@ namespace MSBuild.ExtensionPack.VisualStudio
         /// AcceptMerge
         /// </summary>
         AcceptMerge,
-        
+
         /// <summary>
         /// AcceptTheirs
         /// </summary>
         AcceptTheirs,
-        
+
         /// <summary>
         /// AcceptYours
         /// </summary>
         AcceptYours,
-        
+
         /// <summary>
         /// OverwriteLocal
         /// </summary>
         OverwriteLocal,
-        
+
         /// <summary>
         /// DeleteConflict
         /// </summary>
         DeleteConflict,
-        
+
         /// <summary>
         /// AcceptYoursRenameTheirs
         /// </summary>
@@ -77,7 +77,7 @@ namespace MSBuild.ExtensionPack.VisualStudio
     ///     </ItemGroup>
     ///     <Target Name="Default">
     ///         <!-- Check for pending changes -->
-    ///         <MSBuild.ExtensionPack.VisualStudio.TfsSource TaskAction="GetPendingChanges" ItemPath="$/AProject/APath" WorkingDirectory="C:\Projects\SpeedCMMI">
+    ///         <MSBuild.ExtensionPack.VisualStudio.TfsSource TaskAction="GetPendingChanges" ItemPath="$/AProject/APath" WorkingDirectory="C:\Projects\SpeedCMMI" User="$USERNAME">
     ///             <Output TaskParameter="PendingChanges" PropertyName="PendingChangesText" />
     ///             <Output TaskParameter="PendingChangesExist" PropertyName="DoChangesExist" />
     ///         </MSBuild.ExtensionPack.VisualStudio.TfsSource>
@@ -230,6 +230,11 @@ namespace MSBuild.ExtensionPack.VisualStudio
         public string Login { get; set; }
 
         /// <summary>
+        /// Set the user
+        /// </summary>
+        public string User { get; set; }
+
+        /// <summary>
         /// Sets whether the Tfs operation should be recursive. Default is true.
         /// </summary>
         public bool Recursive
@@ -361,7 +366,13 @@ namespace MSBuild.ExtensionPack.VisualStudio
 
         private void GetPendingChanges()
         {
-            this.ExecuteCommand("status", string.Empty, "/Format:detailed /user:* /recursive");
+            string user = "*";
+            if (!string.IsNullOrEmpty(this.User))
+            {
+                user = string.Format("/user:\"{0}\"", this.User);
+            }
+
+            this.ExecuteCommand("status", string.Format(CultureInfo.CurrentCulture, "{0}", user), "/Format:detailed /recursive");
             this.PendingChanges = this.returnOutput;
             this.PendingChangesExistItem = new TaskItem[1];
             ITaskItem t = new TaskItem(this.ItemPath);
@@ -400,7 +411,7 @@ namespace MSBuild.ExtensionPack.VisualStudio
 
             if (!string.IsNullOrEmpty(this.Comments))
             {
-                 args += string.Format(CultureInfo.CurrentCulture, "/comment:\"{0}\"", this.Comments);
+                args += string.Format(CultureInfo.CurrentCulture, "/comment:\"{0}\"", this.Comments);
             }
 
             this.ExecuteCommand("label " + this.LabelName, args, "/noprompt /recursive");

--- a/Solutions/Main/Framework/VisualStudio/TFSSource.cs
+++ b/Solutions/Main/Framework/VisualStudio/TFSSource.cs
@@ -369,7 +369,7 @@ namespace MSBuild.ExtensionPack.VisualStudio
             string user = "*";
             if (!string.IsNullOrEmpty(this.User))
             {
-                user = string.Format("/user:\"{0}\"", this.User);
+                user = string.Format(CultureInfo.CurrentCulture, "/user:\"{0}\"", this.User);
             }
 
             this.ExecuteCommand("status", string.Format(CultureInfo.CurrentCulture, "{0}", user), "/Format:detailed /recursive");

--- a/Solutions/Main/Framework/VisualStudio/TFSSource.cs
+++ b/Solutions/Main/Framework/VisualStudio/TFSSource.cs
@@ -369,10 +369,10 @@ namespace MSBuild.ExtensionPack.VisualStudio
             string user = "*";
             if (!string.IsNullOrEmpty(this.User))
             {
-                user = string.Format(CultureInfo.CurrentCulture, "/user:\"{0}\"", this.User);
+                user = this.User;
             }
 
-            this.ExecuteCommand("status", string.Format(CultureInfo.CurrentCulture, "{0}", user), "/Format:detailed /recursive");
+            this.ExecuteCommand("status", string.Format(CultureInfo.CurrentCulture, "/user:\"{0}\"", user), "/Format:detailed /recursive");
             this.PendingChanges = this.returnOutput;
             this.PendingChangesExistItem = new TaskItem[1];
             ITaskItem t = new TaskItem(this.ItemPath);

--- a/Solutions/Main/Framework/XmlSamples/TFSSource.proj
+++ b/Solutions/Main/Framework/XmlSamples/TFSSource.proj
@@ -9,7 +9,7 @@
     </ItemGroup>
     <Target Name="Default">
         <!-- Check for pending changes -->
-        <MSBuild.ExtensionPack.VisualStudio.TfsSource TaskAction="GetPendingChanges" ItemPath="$/AProject/APath" WorkingDirectory="C:\Projects\SpeedCMMI">
+        <MSBuild.ExtensionPack.VisualStudio.TfsSource TaskAction="GetPendingChanges" ItemPath="$/AProject/APath" WorkingDirectory="C:\Projects\SpeedCMMI" User="$(USERNAME)">
             <Output TaskParameter="PendingChanges" PropertyName="PendingChangesText" />
             <Output TaskParameter="PendingChangesExist" PropertyName="DoChangesExist" />
         </MSBuild.ExtensionPack.VisualStudio.TfsSource>

--- a/Solutions/Main/Loggers/Framework/XmlFileLogger.cs
+++ b/Solutions/Main/Loggers/Framework/XmlFileLogger.cs
@@ -3,6 +3,8 @@
 //-----------------------------------------------------------------------
 namespace MSBuild.ExtensionPack.Loggers
 {
+    using Microsoft.Build.Framework;
+    using Microsoft.Build.Utilities;
     using System;
     using System.Collections;
     using System.Collections.Generic;
@@ -12,8 +14,6 @@ namespace MSBuild.ExtensionPack.Loggers
     using System.Security;
     using System.Text;
     using System.Xml;
-    using Microsoft.Build.Framework;
-    using Microsoft.Build.Utilities;
 
     /// <summary>
     /// <para>This logger can be used to log in xml format</para>
@@ -135,7 +135,7 @@ namespace MSBuild.ExtensionPack.Loggers
                 this.xmlWriter = new XmlTextWriter(this.logFileName, this.encoding) { Formatting = Formatting.Indented };
                 this.xmlWriter.WriteStartDocument();
                 this.xmlWriter.WriteStartElement("build");
-                this.xmlWriter.Flush();                
+                this.xmlWriter.Flush();
             }
             catch (Exception exception)
             {
@@ -163,10 +163,10 @@ namespace MSBuild.ExtensionPack.Loggers
             this.xmlWriter.WriteValue(this.errors);
             this.xmlWriter.WriteEndElement();
             this.xmlWriter.WriteStartElement("starttime");
-            this.xmlWriter.WriteValue(this.startTime.ToString());
+            this.xmlWriter.WriteValue(this.startTime.ToString(CultureInfo.CurrentCulture));
             this.xmlWriter.WriteEndElement();
             this.xmlWriter.WriteStartElement("endtime");
-            this.xmlWriter.WriteValue(DateTime.UtcNow.ToString());
+            this.xmlWriter.WriteValue(DateTime.UtcNow.ToString(CultureInfo.CurrentCulture));
             this.xmlWriter.WriteEndElement();
             this.xmlWriter.WriteStartElement("timeelapsed");
             TimeSpan s = DateTime.UtcNow - this.startTime;
@@ -309,10 +309,10 @@ namespace MSBuild.ExtensionPack.Loggers
                 return;
             }
 
-			// Avoid CDATA in CDATA
-			message = message.Replace("<![CDATA[", "");
-			message = message.Replace("]]>", "");
-			
+            // Avoid CDATA in CDATA
+            message = message.Replace("<![CDATA[", "");
+            message = message.Replace("]]>", "");
+
             message = message.Replace("&", "&amp;");
             if (escape)
             {

--- a/Solutions/Main/TFS2012/TeamBuild.cs
+++ b/Solutions/Main/TFS2012/TeamBuild.cs
@@ -3,13 +3,13 @@
 //-----------------------------------------------------------------------
 namespace MSBuild.ExtensionPack.Tfs2012
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
     using Microsoft.TeamFoundation.Build.Client;
     using Microsoft.TeamFoundation.Client;
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
 
     /// <summary>
     /// <b>Valid TaskActions are:</b>
@@ -283,16 +283,16 @@ namespace MSBuild.ExtensionPack.Tfs2012
             {
                 buildDetailSpec.DefinitionSpec.Name = this.BuildDefinitionName;
             }
-            
+
             // Only get latest
-            buildDetailSpec.MaxBuildsPerDefinition = 1; 
-            buildDetailSpec.QueryOrder = BuildQueryOrder.FinishTimeDescending; 
+            buildDetailSpec.MaxBuildsPerDefinition = 1;
+            buildDetailSpec.QueryOrder = BuildQueryOrder.FinishTimeDescending;
             if (!string.IsNullOrEmpty(this.Status))
             {
                 this.LogTaskMessage(MessageImportance.Low, string.Format(CultureInfo.CurrentCulture, "Filtering on Status: {0}", this.Status));
                 buildDetailSpec.Status = (BuildStatus)System.Enum.Parse(typeof(BuildStatus), this.buildStatus);
             }
-            
+
             // do the search and extract the details from the singleton expected result
             IBuildQueryResult results = this.buildServer.QueryBuilds(buildDetailSpec);
 
@@ -307,18 +307,18 @@ namespace MSBuild.ExtensionPack.Tfs2012
                 ibuildDef.SetMetadata("CompilationStatus", this.buildDetails.CompilationStatus.ToString());
                 ibuildDef.SetMetadata("CompilationSuccess", this.buildDetails.CompilationStatus == BuildPhaseStatus.Succeeded ? "true" : "false");
                 ibuildDef.SetMetadata("DropLocation", this.buildDetails.DropLocation ?? string.Empty);
-                ibuildDef.SetMetadata("FinishTime", this.buildDetails.FinishTime.ToString());
+                ibuildDef.SetMetadata("FinishTime", this.buildDetails.FinishTime.ToString(CultureInfo.CurrentCulture));
                 ibuildDef.SetMetadata("KeepForever", this.buildDetails.KeepForever.ToString());
                 ibuildDef.SetMetadata("LabelName", this.buildDetails.LabelName ?? string.Empty);
                 ibuildDef.SetMetadata("LastChangedBy", this.buildDetails.LastChangedBy ?? string.Empty);
-                ibuildDef.SetMetadata("LastChangedOn", this.buildDetails.LastChangedOn.ToString());
+                ibuildDef.SetMetadata("LastChangedOn", this.buildDetails.LastChangedOn.ToString(CultureInfo.CurrentCulture));
                 ibuildDef.SetMetadata("LogLocation", this.buildDetails.LogLocation ?? string.Empty);
                 ibuildDef.SetMetadata("Quality", this.buildDetails.Quality ?? string.Empty);
                 ibuildDef.SetMetadata("Reason", this.buildDetails.Reason.ToString());
                 ibuildDef.SetMetadata("RequestedBy", this.buildDetails.RequestedBy ?? string.Empty);
                 ibuildDef.SetMetadata("RequestedFor", this.buildDetails.RequestedFor ?? string.Empty);
                 ibuildDef.SetMetadata("SourceGetVersion", this.buildDetails.SourceGetVersion ?? string.Empty);
-                ibuildDef.SetMetadata("StartTime", this.buildDetails.StartTime.ToString() ?? string.Empty);
+                ibuildDef.SetMetadata("StartTime", this.buildDetails.StartTime.ToString(CultureInfo.CurrentCulture) ?? string.Empty);
                 ibuildDef.SetMetadata("Status", this.buildDetails.Status.ToString() ?? string.Empty);
                 ibuildDef.SetMetadata("TestStatus", this.buildDetails.TestStatus.ToString() ?? string.Empty);
                 ibuildDef.SetMetadata("TestSuccess", this.buildDetails.TestStatus == BuildPhaseStatus.Succeeded ? "true" : "false");

--- a/Solutions/Main/TFS2013/TeamBuild.cs
+++ b/Solutions/Main/TFS2013/TeamBuild.cs
@@ -3,13 +3,13 @@
 //-----------------------------------------------------------------------
 namespace MSBuild.ExtensionPack.Tfs2013
 {
-    using System;
-    using System.Collections.Generic;
-    using System.Globalization;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
     using Microsoft.TeamFoundation.Build.Client;
     using Microsoft.TeamFoundation.Client;
+    using System;
+    using System.Collections.Generic;
+    using System.Globalization;
 
     /// <summary>
     /// <b>Valid TaskActions are:</b>
@@ -262,7 +262,7 @@ namespace MSBuild.ExtensionPack.Tfs2013
             {
                 request.DropLocation = this.DropLocation;
             }
-            
+
             // queue the build
             var queuedBuild = this.buildServer.QueueBuild(request, QueueOptions.None);
             this.LogTaskMessage(string.Format(CultureInfo.CurrentCulture, "The build is now in state {0}", queuedBuild.Status));
@@ -283,16 +283,16 @@ namespace MSBuild.ExtensionPack.Tfs2013
             {
                 buildDetailSpec.DefinitionSpec.Name = this.BuildDefinitionName;
             }
-            
+
             // Only get latest
-            buildDetailSpec.MaxBuildsPerDefinition = 1; 
-            buildDetailSpec.QueryOrder = BuildQueryOrder.FinishTimeDescending; 
+            buildDetailSpec.MaxBuildsPerDefinition = 1;
+            buildDetailSpec.QueryOrder = BuildQueryOrder.FinishTimeDescending;
             if (!string.IsNullOrEmpty(this.Status))
             {
                 this.LogTaskMessage(MessageImportance.Low, string.Format(CultureInfo.CurrentCulture, "Filtering on Status: {0}", this.Status));
                 buildDetailSpec.Status = (BuildStatus)System.Enum.Parse(typeof(BuildStatus), this.buildStatus);
             }
-            
+
             // do the search and extract the details from the singleton expected result
             IBuildQueryResult results = this.buildServer.QueryBuilds(buildDetailSpec);
 
@@ -307,18 +307,18 @@ namespace MSBuild.ExtensionPack.Tfs2013
                 ibuildDef.SetMetadata("CompilationStatus", this.buildDetails.CompilationStatus.ToString());
                 ibuildDef.SetMetadata("CompilationSuccess", this.buildDetails.CompilationStatus == BuildPhaseStatus.Succeeded ? "true" : "false");
                 ibuildDef.SetMetadata("DropLocation", this.buildDetails.DropLocation ?? string.Empty);
-                ibuildDef.SetMetadata("FinishTime", this.buildDetails.FinishTime.ToString());
+                ibuildDef.SetMetadata("FinishTime", this.buildDetails.FinishTime.ToString(CultureInfo.CurrentCulture));
                 ibuildDef.SetMetadata("KeepForever", this.buildDetails.KeepForever.ToString());
                 ibuildDef.SetMetadata("LabelName", this.buildDetails.LabelName ?? string.Empty);
                 ibuildDef.SetMetadata("LastChangedBy", this.buildDetails.LastChangedBy ?? string.Empty);
-                ibuildDef.SetMetadata("LastChangedOn", this.buildDetails.LastChangedOn.ToString());
+                ibuildDef.SetMetadata("LastChangedOn", this.buildDetails.LastChangedOn.ToString(CultureInfo.CurrentCulture));
                 ibuildDef.SetMetadata("LogLocation", this.buildDetails.LogLocation ?? string.Empty);
                 ibuildDef.SetMetadata("Quality", this.buildDetails.Quality ?? string.Empty);
                 ibuildDef.SetMetadata("Reason", this.buildDetails.Reason.ToString());
                 ibuildDef.SetMetadata("RequestedBy", this.buildDetails.RequestedBy ?? string.Empty);
                 ibuildDef.SetMetadata("RequestedFor", this.buildDetails.RequestedFor ?? string.Empty);
                 ibuildDef.SetMetadata("SourceGetVersion", this.buildDetails.SourceGetVersion ?? string.Empty);
-                ibuildDef.SetMetadata("StartTime", this.buildDetails.StartTime.ToString() ?? string.Empty);
+                ibuildDef.SetMetadata("StartTime", this.buildDetails.StartTime.ToString(CultureInfo.CurrentCulture) ?? string.Empty);
                 ibuildDef.SetMetadata("Status", this.buildDetails.Status.ToString() ?? string.Empty);
                 ibuildDef.SetMetadata("TestStatus", this.buildDetails.TestStatus.ToString() ?? string.Empty);
                 ibuildDef.SetMetadata("TestSuccess", this.buildDetails.TestStatus == BuildPhaseStatus.Succeeded ? "true" : "false");


### PR DESCRIPTION
Because release is made by individuals, we needed a way to check that local working copy was not suffering of any local changes.
Previous /user:* parameter was looking for any changes in the team.

Setting user in the task would target only changes made by a single user

NB1: I'm not sure whether UserName property could have been used in the same manner ?
NB2: I had to set CultureInfo.CurrentCulture in toString method of Datetime to have my build succeed