### PR TITLE
Make nunit3 output format configurable

### DIFF
--- a/Solutions/Main/Framework/CodeQuality/NUnit3.cs
+++ b/Solutions/Main/Framework/CodeQuality/NUnit3.cs
@@ -288,7 +288,7 @@ namespace MSBuild.ExtensionPack.CodeQuality
             builder.AppendSwitchIfNotNull("--domain=", this.Domain);
             builder.AppendSwitchIfNotNull("--framework=", this.Framework);
 
-            var resultSwitchFormatFlag = ";format=nunit" + UseNUnitV2ResultWriter ? "3" : "2";
+            var resultSwitchFormatFlag = ";format=nunit" + UseNUnitV3ResultWriter ? "3" : "2";
             if (this.OutputXmlFile != null)
             {
                 builder.AppendSwitch("--result=" + this.OutputXmlFile + resultSwitchFormatFlag);

--- a/Solutions/Main/Framework/CodeQuality/NUnit3.cs
+++ b/Solutions/Main/Framework/CodeQuality/NUnit3.cs
@@ -106,10 +106,10 @@ namespace MSBuild.ExtensionPack.CodeQuality
         public int Agents { get; set; }
 
         /// <summary>
-        /// Specify if the legacy output writer from NUnit V2 should be used. If true, it will add
-        /// the flag "format=nunit2" to the --result switch, otherwise "format=nunit3".
+        /// Specify if the output writer from NUnit V3 should be used. If true, it will add
+        /// the flag "format=nunit3" to the --result switch, otherwise "format=nunit2".
         /// </summary>
-        public bool UseNUnitV2ResultWriter { get; set; }
+        public bool UseNUnitV3ResultWriter { get; set; }
 
         /// <summary>
         /// Sets the OutputXmlFile name
@@ -288,7 +288,7 @@ namespace MSBuild.ExtensionPack.CodeQuality
             builder.AppendSwitchIfNotNull("--domain=", this.Domain);
             builder.AppendSwitchIfNotNull("--framework=", this.Framework);
 
-            var resultSwitchFormatFlag = ";format=nunit" + UseNUnitV2ResultWriter ? "2" : "3";
+            var resultSwitchFormatFlag = ";format=nunit" + UseNUnitV2ResultWriter ? "3" : "2";
             if (this.OutputXmlFile != null)
             {
                 builder.AppendSwitch("--result=" + this.OutputXmlFile + resultSwitchFormatFlag);

--- a/Solutions/Main/Framework/CodeQuality/NUnit3.cs
+++ b/Solutions/Main/Framework/CodeQuality/NUnit3.cs
@@ -106,6 +106,12 @@ namespace MSBuild.ExtensionPack.CodeQuality
         public int Agents { get; set; }
 
         /// <summary>
+        /// Specify if the legacy output writer from NUnit V2 should be used. If true, it will add
+        /// the flag "format=nunit2" to the --result switch.
+        /// </summary>
+        public bool UseNUnitV2ResultWriter { get; set; }
+
+        /// <summary>
         /// Sets the OutputXmlFile name
         /// </summary>
         public ITaskItem OutputXmlFile { get; set; }

--- a/Solutions/Main/Framework/CodeQuality/NUnit3.cs
+++ b/Solutions/Main/Framework/CodeQuality/NUnit3.cs
@@ -288,13 +288,14 @@ namespace MSBuild.ExtensionPack.CodeQuality
             builder.AppendSwitchIfNotNull("--domain=", this.Domain);
             builder.AppendSwitchIfNotNull("--framework=", this.Framework);
 
+            var resultSwitchFormatFlag = ";format=nunit" + UseNUnitV2ResultWriter ? "2" : "3";
             if (this.OutputXmlFile != null)
             {
-                builder.AppendSwitch("--result=" + this.OutputXmlFile + ";format=nunit2");
+                builder.AppendSwitch("--result=" + this.OutputXmlFile + resultSwitchFormatFlag);
             }
             else
             {
-                builder.AppendSwitch("--result=TestResult.xml;format=nunit2");
+                builder.AppendSwitch($"--result=TestResult.xml{resultSwitchFormatFlag}");
             }
 
             builder.AppendSwitchIfNotNull("--err=", this.ErrorOutputFile);

--- a/Solutions/Main/Framework/CodeQuality/NUnit3.cs
+++ b/Solutions/Main/Framework/CodeQuality/NUnit3.cs
@@ -288,7 +288,7 @@ namespace MSBuild.ExtensionPack.CodeQuality
             builder.AppendSwitchIfNotNull("--domain=", this.Domain);
             builder.AppendSwitchIfNotNull("--framework=", this.Framework);
 
-            var resultSwitchFormatFlag = ";format=nunit" + UseNUnitV3ResultWriter ? "3" : "2";
+            var resultSwitchFormatFlag = ";format=nunit" + (this.UseNUnitV3ResultWriter ? "3" : "2");
             if (this.OutputXmlFile != null)
             {
                 builder.AppendSwitch("--result=" + this.OutputXmlFile + resultSwitchFormatFlag);

--- a/Solutions/Main/Framework/CodeQuality/NUnit3.cs
+++ b/Solutions/Main/Framework/CodeQuality/NUnit3.cs
@@ -107,7 +107,7 @@ namespace MSBuild.ExtensionPack.CodeQuality
 
         /// <summary>
         /// Specify if the legacy output writer from NUnit V2 should be used. If true, it will add
-        /// the flag "format=nunit2" to the --result switch.
+        /// the flag "format=nunit2" to the --result switch, otherwise "format=nunit3".
         /// </summary>
         public bool UseNUnitV2ResultWriter { get; set; }
 


### PR DESCRIPTION
To be able to set the output format within the "--result" switch, there now is a new property, which appends ";format=nunit3" if set to true. Otherwise it will append the former "format=nunit2".