### PR TITLE
Powershell task factory execution policy issue

### DIFF
--- a/Solutions/Main/TaskFactories/PowershellTaskFactory/PowerShellTask.cs
+++ b/Solutions/Main/TaskFactories/PowershellTaskFactory/PowerShellTask.cs
@@ -34,6 +34,32 @@ namespace MSBuild.ExtensionPack.TaskFactory
             this.pipeline.Commands.AddScript(script);
             this.pipeline.Runspace.Open();
             this.pipeline.Runspace.SessionStateProxy.SetVariable("log", this.Log);
+            this.pipeline.Output.DataReady += Output_DataReady;
+            this.pipeline.Error.DataReady += Error_DataReady;
+        }
+
+        private void Error_DataReady(object sender, EventArgs e)
+        {
+	        var error = sender as PipelineReader<object>;
+	        if (error != null)
+            {
+                while (error.Count > 0)
+                {
+                    Log.LogError(error.Read().ToString());
+                }
+            }
+        }
+
+        private void Output_DataReady(object sender, EventArgs e)
+        {
+	        var output = sender as PipelineReader<PSObject>;
+	        if (output != null)
+            {
+                while (output.Count > 0)
+                {
+                    Log.LogMessage(output.Read().ToString());
+                }
+            }
         }
 
         public object GetPropertyValue(TaskPropertyInfo property)

--- a/Solutions/Main/TaskFactories/PowershellTaskFactory/PowerShellTask.cs
+++ b/Solutions/Main/TaskFactories/PowershellTaskFactory/PowerShellTask.cs
@@ -6,6 +6,7 @@ namespace MSBuild.ExtensionPack.TaskFactory
 {
     using System;
     using System.Diagnostics.Contracts;
+    using System.Management.Automation;
     using System.Management.Automation.Runspaces;
     using Microsoft.Build.Framework;
     using Microsoft.Build.Utilities;
@@ -22,6 +23,13 @@ namespace MSBuild.ExtensionPack.TaskFactory
 
         internal PowerShellTask(string script)
         {
+            // ExecutionPolicy Bypass
+            InitialSessionState initial = InitialSessionState.CreateDefault();
+
+            // Replace PSAuthorizationManager with a null manager
+            // which ignores execution policy
+            initial.AuthorizationManager = new AuthorizationManager("Microsoft.PowerShell");
+
             this.pipeline = RunspaceFactory.CreateRunspace().CreatePipeline();
             this.pipeline.Commands.AddScript(script);
             this.pipeline.Runspace.Open();

--- a/Solutions/Main/TaskFactories/PowershellTaskFactory/PowershellTaskFactory.csproj
+++ b/Solutions/Main/TaskFactories/PowershellTaskFactory/PowershellTaskFactory.csproj
@@ -53,9 +53,8 @@
     <Reference Include="Microsoft.Build.Utilities.v4.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.Management.Automation, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(WinDir)\assembly\GAC_MSIL\System.Management.Automation\1.0.0.0__31bf3856ad364e35\System.Management.Automation.dll</HintPath>
+    <Reference Include="System.Management.Automation, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Microsoft.PowerShell.5.ReferenceAssemblies.1.1.0\lib\net4\System.Management.Automation.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -68,6 +67,7 @@
     <Compile Include="Properties\ExtraAssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="packages.config" />
     <None Include="XmlSamples\PowerShellTaskFactory.proj" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/Solutions/Main/TaskFactories/PowershellTaskFactory/packages.config
+++ b/Solutions/Main/TaskFactories/PowershellTaskFactory/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.PowerShell.5.ReferenceAssemblies" version="1.1.0" targetFramework="net40" />
+</packages>


### PR DESCRIPTION
I stumbled upon the fact that powershell task factory has issues with execution policy when run on Windows 10. Basically, it won't run even if machine has them completely turned off. Some people encountered similar issue on similar code: https://github.com/michaelburns/LaunchPad/issues/5
There is reference to the blog post in that issue, sadly it's dead already. I'm not powershell expert, but just mimicking their solution worked for me. While at it I also looked up how to intercept outputs from powershell pipeline and added respective code.